### PR TITLE
Support Fedora Silverblue

### DIFF
--- a/autohck.sh
+++ b/autohck.sh
@@ -20,8 +20,15 @@ install_ruby() {
       ;;
 
     fedora)
-      sudo dnf makecache
-      sudo dnf -y install tar openssl openssl-devel curl curl-devel
+      case "$( get_distribution_variant )" in
+        silverblue)
+          rpm-ostree install -A --allow-inactive --idempotent tar openssl openssl-devel curl curl-devel
+          ;;
+        *)
+          sudo dnf makecache
+          sudo dnf -y install tar openssl openssl-devel curl curl-devel
+          ;;
+        esac
       ;;
 
     *)
@@ -71,8 +78,15 @@ install_deps_autohck() {
       ;;
 
     fedora)
-      sudo dnf makecache
-      sudo dnf -y install net-tools ethtool bridge-utils genisoimage jq
+      case "$( get_distribution_variant )" in
+        silverblue)
+          rpm-ostree install -A --allow-inactive --idempotent net-tools ethtool bridge-utils genisoimage jq
+          ;;
+        *)
+          sudo dnf makecache
+          sudo dnf -y install net-tools ethtool bridge-utils genisoimage jq
+          ;;
+        esac
       ;;
 
     *)

--- a/helpers.sh
+++ b/helpers.sh
@@ -12,6 +12,16 @@ get_distribution() {
     echo "$lsb_dist" | tr '[:upper:]' '[:lower:]'
 }
 
+get_distribution_variant() {
+  variant=""
+
+  if [ -r /etc/os-release ]; then
+    variant="$(. /etc/os-release && echo "$VARIANT_ID")"
+  fi
+
+  echo "$variant" | tr '[:upper:]' '[:lower:]'
+}
+
 command_exists() {
     command -v "$@" > /dev/null 2>&1
 }

--- a/qemu.sh
+++ b/qemu.sh
@@ -19,12 +19,23 @@ install_deps_qemu() {
       ;;
 
     fedora)
-      sudo dnf makecache
-      sudo dnf install -y git gcc g++ make meson pkg-config zlib-devel glib2-devel pixman-devel libtool \
-        dh-autoreconf bridge-utils libpng-devel libjpeg-devel SDL2-devel gtk3-devel libaio-devel \
-        libnfs-devel libseccomp-devel libiscsi-devel libzstd-devel curl-devel keyutils-libs-devel \
-        libfdt-devel libu2f-server-devel libu2f-host-devel libglusterfs-devel librados-devel \
-        spice-server-devel libusb-devel libusb1-devel usbredir-devel libcap-ng-devel libattr-devel
+      case "$( get_distribution_variant )" in
+        silverblue)
+          rpm-ostree install -A --allow-inactive --idempotent git gcc g++ make meson pkg-config zlib-devel glib2-devel pixman-devel libtool \
+            dh-autoreconf bridge-utils libpng-devel libjpeg-devel SDL2-devel gtk3-devel libaio-devel \
+            libnfs-devel libseccomp-devel libiscsi-devel libzstd-devel curl-devel keyutils-libs-devel \
+            libfdt-devel libu2f-server-devel libu2f-host-devel libglusterfs-devel librados-devel \
+            spice-server-devel libusb-devel libusb1-devel usbredir-devel libcap-ng-devel libattr-devel
+          ;;
+        *)
+          sudo dnf makecache
+          sudo dnf install -y git gcc g++ make meson pkg-config zlib-devel glib2-devel pixman-devel libtool \
+            dh-autoreconf bridge-utils libpng-devel libjpeg-devel SDL2-devel gtk3-devel libaio-devel \
+            libnfs-devel libseccomp-devel libiscsi-devel libzstd-devel curl-devel keyutils-libs-devel \
+            libfdt-devel libu2f-server-devel libu2f-host-devel libglusterfs-devel librados-devel \
+            spice-server-devel libusb-devel libusb1-devel usbredir-devel libcap-ng-devel libattr-devel
+          ;;
+        esac
       ;;
 
     *)


### PR DESCRIPTION
As DHCPSeverSetup supports Fedora Silverblue since commit 8d642ec3de1bd40b3037fe12dca6c6459eec07ee, support it on AutoHCK-Installer, too.

Signed-off-by: Akihiko Odaki <akihiko.odaki@daynix.com>