### PR TITLE
Allow to use Podman

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ for i in "$@"; do
 done
 
 command_exists jq || log_fatal "jq command does not exist"
-command_exists docker || log_fatal "docker command does not exist"
+command_exists docker || command_exists podman || log_fatal "Compatible OCI runtime does not exist"
 
 NET_BRIDGE=br_autohck
 NET_BRIDGE_SUBNET=192.168.0.


### PR DESCRIPTION
The existence check of Docker was there for DHCPServerSetup, and it supports Podman as an alternative OCI runtime since commit 945af1552921f94d6c74d31763e394cd8ada5132.

Signed-off-by: Akihiko Odaki \<akihiko.odaki@daynix.com\>