### PR TITLE
Check if /dev/kvm is accessible

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,9 @@ for i in "$@"; do
   esac
 done
 
+[ -r /dev/kvm ] || log_fatal '/dev/kvm is not readable. Make sure /dev/kvm has right permissions and the user belongs to the corresponding group.'
+[ -w /dev/kvm ] || log_fatal '/dev/kvm is not writable. Make sure /dev/kvm has right permissions and the user belongs to the corresponding group.'
+
 command_exists jq || log_fatal "jq command does not exist"
 
 [ ! -f "${bootstrap}" ] || source "${bootstrap}"


### PR DESCRIPTION
The sanity test for QEMU/KVM is being done by QEMU repository post-clone hook, but these checks provides better hints for to troubleshoot in the particular case where /dev/kvm is not accessible.

Signed-off-by: Akihiko Odaki \<akihiko.odaki@daynix.com\>

@kostyanf14 This can be better than noting about the problem on the wiki, which users can miss.