### PR TITLE
Add print_usage function referenced in the script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,10 @@ source "${work_dir}/qemu.sh"
 source "${work_dir}/virtiofsd.sh"
 source "${work_dir}/autohck.sh"
 
+print_usage() {
+  echo "Usage: install.sh [--silent]" >&2
+}
+
 for i in "$@"; do
   case $i in
     --silent)


### PR DESCRIPTION
The argument parser calls print_usage on invalid options, but the function did not exist. That would cause a runtime error (print_usage: command not found) instead of a clean error message.
```
AutoHCK-Installer]# ./install.sh --help
ERROR:  Unknown option: --help 
./install.sh: line 25: print_usage: command not found
```

This PR:

- Adds the missing print_usage() helper to `install.sh`, which was already called when an unknown CLI flag is passed but was never defined.

- Prints a short usage line to stderr: `Usage: install.sh [--silent].`
```
AutoHCK-Installer]# ./install.sh --help
ERROR:  Unknown option: --help 
Usage: install.sh [--silent]
```

